### PR TITLE
Enhance menu routes and DB schema

### DIFF
--- a/backend_easycook/src/routes/menu.ts
+++ b/backend_easycook/src/routes/menu.ts
@@ -1,46 +1,236 @@
 import { Hono } from "hono";
 import { getDb } from "../db";
-import * as z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 
 const menu = new Hono()
 
-//All menu
+// All menu
 menu.get('/', async (c) => {
     try {
         const db = getDb(c)
-        const r = await db.prepare('SELECT * FROM menu').all()
-        return c.json(r.results || [])
+
+        const menuList = await db.prepare(`
+            SELECT 
+                m.*,
+                c.categoryname,
+                u.name          AS author_name,
+                u.username      AS author_username,
+                u.profile_image AS author_image
+            FROM menu m
+            JOIN category c ON m.categoryid = c.categoryid
+            JOIN users u    ON m.uid = u.uid
+            WHERE m.status = 'published'
+            ORDER BY m.created_at DESC
+        `).all()
+
+        if (!menuList.results || menuList.results.length === 0) {
+            return c.json([])
+        }
+
+        // ดึง ingredients และ steps ของทุกเมนูพร้อมกัน
+        const menuIds = menuList.results.map((m: any) => m.menuid)
+        const placeholders = menuIds.map(() => '?').join(', ')
+
+        const [ingredients, steps] = await Promise.all([
+            db.prepare(`
+                SELECT * FROM ingredient
+                WHERE menuid IN (${placeholders})
+                ORDER BY menuid, ingredient_order
+            `).bind(...menuIds).all(),
+
+            db.prepare(`
+                SELECT * FROM makestep
+                WHERE menuid IN (${placeholders})
+                ORDER BY menuid, step_order
+            `).bind(...menuIds).all(),
+        ])
+
+        // Group ingredients และ steps ตาม menuid
+        const ingredientMap: Record<number, any[]> = {}
+        const stepMap: Record<number, any[]> = {}
+
+        for (const ing of ingredients.results) {
+            const id = (ing as any).menuid
+            if (!ingredientMap[id]) ingredientMap[id] = []
+            ingredientMap[id].push(ing)
+        }
+
+        for (const step of steps.results) {
+            const id = (step as any).menuid
+            if (!stepMap[id]) stepMap[id] = []
+            stepMap[id].push(step)
+        }
+
+        const result = menuList.results.map((m: any) => ({
+            ...m,
+            ingredients: ingredientMap[m.menuid] || [],
+            steps:       stepMap[m.menuid]       || [],
+        }))
+
+        return c.json(result)
+
     } catch (err: any) {
-        return c.json(
-            { error: err?.message || String(err) },
-            500
-        )
+        return c.json({ error: err?.message || String(err) }, 500)
     }
 })
 
-//menu + วิธีทำ + วัตถุดิบ
+//menu+วัตถุดิบ,ขั้นตอน by ID
 menu.get('/:menuid', async (c) => {
     try {
         const menuid = Number(c.req.param('menuid'))
         if (Number.isNaN(menuid)) {
-            return c.json ({ error: 'Invalid menu id' }, 400)
+            return c.json({ error: 'Invalid menu id' }, 400)
         }
+
         const db = getDb(c)
-        const r = await db
-        .prepare(`SELECT * FROM menu WHERE menuid = ?`)
-        .bind(menuid)
-        .all()
-        const menu = r.results?.[0]
-        if (!menu) {
+
+        // ดึงข้อมูลเมนู + ชื่อ category + ชื่อ user พร้อมกัน
+        const [menuRow, ingredients, steps] = await Promise.all([
+            db.prepare(`
+                SELECT 
+                    m.*,
+                    c.categoryname,
+                    u.name     AS author_name,
+                    u.username AS author_username,
+                    u.profile_image AS author_image
+                FROM menu m
+                JOIN category c ON m.categoryid = c.categoryid
+                JOIN users u    ON m.uid = u.uid
+                WHERE m.menuid = ?
+            `).bind(menuid).first(),
+
+            db.prepare(`
+                SELECT ingredient_order, ingredient_name
+                FROM ingredient
+                WHERE menuid = ?
+                ORDER BY ingredient_order
+            `).bind(menuid).all(),
+
+            db.prepare(`
+                SELECT step_order, step, step_image
+                FROM makestep
+                WHERE menuid = ?
+                ORDER BY step_order
+            `).bind(menuid).all(),
+        ])
+
+        if (!menuRow) {
             return c.json({ error: 'Not found' }, 404)
         }
-        return c.json(menu)
+
+        return c.json({
+            ...menuRow,
+            ingredients: ingredients.results,
+            steps: steps.results,
+        })
+
     } catch (err: any) {
-        return c.json(
-            { error: err?.message || String(err) },
-            500
+        return c.json({ error: err?.message || String(err) }, 500)
+    }
+})
+
+menu.post('/', async (c) => {
+    try {
+        const body = await c.req.json()
+
+        const { uid, categoryid, mname, cooktime,
+                description, cover_image,
+                status = 'published',
+                ingredients = [], steps = [] } = body
+
+        // Validate fields หลัก
+        if (!uid || !categoryid || !mname || !cooktime) {
+            return c.json({ error: 'uid, categoryid, mname, cooktime are required' }, 400)
+        }
+        if (!Array.isArray(ingredients) || ingredients.length === 0) {
+            return c.json({ error: 'ingredients must be a non-empty array' }, 400)
+        }
+        if (!Array.isArray(steps) || steps.length === 0) {
+            return c.json({ error: 'steps must be a non-empty array' }, 400)
+        }
+
+        const db = getDb(c)
+
+        // 1. INSERT menu
+        const menuResult = await db.prepare(`
+            INSERT INTO menu (uid, categoryid, mname, cooktime, description, cover_image, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).bind(
+            uid, categoryid, mname, cooktime,
+            description ?? null,
+            cover_image ?? null,
+            status
+        ).run()
+
+        const menuid = menuResult.meta.last_row_id
+
+        // 2. INSERT ingredients (batch)
+        const ingredientStmt = db.prepare(`
+            INSERT INTO ingredient (menuid, ingredient_order, ingredient_name)
+            VALUES (?, ?, ?)
+        `)
+        await db.batch(
+            ingredients.map((ing, index) =>
+                ingredientStmt.bind(
+                    menuid,
+                    index + 1,
+                    ing.ingredient_name,
+                )
+            )
         )
+
+        // 3. INSERT steps (batch)
+        const stepStmt = db.prepare(`
+            INSERT INTO makestep (menuid, step_order, step, step_image)
+            VALUES (?, ?, ?, ?)
+        `)
+        await db.batch(
+            steps.map((s, index) =>
+                stepStmt.bind(
+                    menuid,
+                    index + 1,
+                    s.step,
+                    s.step_image ?? null
+                )
+            )
+        )
+
+        return c.json({ message: 'Created', menuid }, 201)
+
+    } catch (err: any) {
+        return c.json({ error: err?.message || String(err) }, 500)
+    }
+})
+
+// ============================================================
+//  DELETE /:menuid  — ลบเมนู (ingredient + step ลบตาม CASCADE)
+// ============================================================
+menu.delete('/:menuid', async (c) => {
+    try {
+        const menuid = Number(c.req.param('menuid'))
+        if (Number.isNaN(menuid)) {
+            return c.json({ error: 'Invalid menu id' }, 400)
+        }
+
+        const db = getDb(c)
+
+        // เช็คก่อนว่ามีเมนูนี้อยู่ไหม
+        const existing = await db.prepare(
+            'SELECT menuid FROM menu WHERE menuid = ?'
+        ).bind(menuid).first()
+
+        if (!existing) {
+            return c.json({ error: 'Not found' }, 404)
+        }
+
+        // ลบ menu — ingredient + makestep จะลบตาม ON DELETE CASCADE อัตโนมัติ
+        await db.prepare(
+            'DELETE FROM menu WHERE menuid = ?'
+        ).bind(menuid).run()
+
+        return c.json({ message: 'Deleted', menuid })
+
+    } catch (err: any) {
+        return c.json({ error: err?.message || String(err) }, 500)
     }
 })
 

--- a/backend_easycook/src/schema.sql
+++ b/backend_easycook/src/schema.sql
@@ -1,42 +1,172 @@
+-- ============================================================
+--  Recipe Website — SQLite Schema (ปรับจากโครงสร้างเดิม)
+-- ============================================================
+
+-- เปิดใช้ Foreign Key (SQLite ต้องเปิดเองทุกครั้ง)
+PRAGMA foreign_keys = ON;
+
+-- ============================================================
+--  1. users — สมาชิก
+-- ============================================================
 CREATE TABLE IF NOT EXISTS users (
-    uid INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    password TEXT NOT NULL,
-    email TEXT UNIQUE NOT NULL,
-    profile_image TEXT
+    uid           INTEGER PRIMARY KEY AUTOINCREMENT,
+    name          TEXT    NOT NULL,
+    username      TEXT    NOT NULL UNIQUE,        -- เพิ่ม: ชื่อผู้ใช้สำหรับแสดงผล
+    email         TEXT    NOT NULL UNIQUE,
+    password      TEXT    NOT NULL,
+    profile_image TEXT,
+    created_at    TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
+-- ============================================================
+--  2. category — หมวดหมู่อาหาร
+-- ============================================================
 CREATE TABLE IF NOT EXISTS category (
-    categoryid INTEGER PRIMARY KEY AUTOINCREMENT,
-    categoryname TEXT NOT NULL UNIQUE
+    categoryid    INTEGER PRIMARY KEY AUTOINCREMENT,
+    categoryname  TEXT    NOT NULL UNIQUE
 );
 
+-- ============================================================
+--  3. menu — สูตรอาหาร
+-- ============================================================
 CREATE TABLE IF NOT EXISTS menu (
-    menuid INTEGER PRIMARY KEY AUTOINCREMENT,
-    uid INTEGER NOT NULL,
-    mname TEXT NOT NULL,
-    cooktime INTEGER NOT NULL,
-    description TEXT,
-    categoryid INTEGER NOT NULL,
-    FOREIGN KEY (uid) REFERENCES users(uid) ON DELETE CASCADE,
+    menuid        INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid           INTEGER NOT NULL,
+    categoryid    INTEGER NOT NULL,
+    mname         TEXT    NOT NULL,
+    cooktime      INTEGER NOT NULL,               -- เวลาทำ (นาที)
+    description   TEXT,
+    cover_image   TEXT,                           -- เพิ่ม: รูปภาพปกอาหาร
+    status        TEXT    NOT NULL DEFAULT 'published'
+                          CHECK (status IN ('draft', 'published')),
+    created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+
+    FOREIGN KEY (uid)        REFERENCES users(uid)         ON DELETE CASCADE,
     FOREIGN KEY (categoryid) REFERENCES category(categoryid)
 );
 
+-- ============================================================
+--  4. ingredient — ส่วนผสม
+-- ============================================================
 CREATE TABLE IF NOT EXISTS ingredient (
-    ingredientid INTEGER PRIMARY KEY AUTOINCREMENT,
-    menuid INTEGER NOT NULL,
+    ingredientid     INTEGER PRIMARY KEY AUTOINCREMENT,
+    menuid           INTEGER NOT NULL,
     ingredient_order INTEGER NOT NULL,
-    ingredient_name TEXT NOT NULL,
+    ingredient_name  TEXT    NOT NULL,
+
     FOREIGN KEY (menuid) REFERENCES menu(menuid) ON DELETE CASCADE,
     UNIQUE (menuid, ingredient_order)
 );
 
+-- ============================================================
+--  5. makestep — ขั้นตอนการทำ
+-- ============================================================
 CREATE TABLE IF NOT EXISTS makestep (
-    stepid INTEGER PRIMARY KEY AUTOINCREMENT,
-    menuid INTEGER NOT NULL,
-    step_order INTEGER NOT NULL,
-    step TEXT NOT NULL,
-    step_image TEXT,
+    stepid      INTEGER PRIMARY KEY AUTOINCREMENT,
+    menuid      INTEGER NOT NULL,
+    step_order  INTEGER NOT NULL,
+    step        TEXT    NOT NULL,
+    step_image  TEXT,
+
     FOREIGN KEY (menuid) REFERENCES menu(menuid) ON DELETE CASCADE,
     UNIQUE (menuid, step_order)
 );
+
+-- ============================================================
+--  6. saved_menu — สูตรที่บันทึกไว้ (กดใจ/bookmark)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS saved_menu (
+    saveid    INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid       INTEGER NOT NULL,
+    menuid    INTEGER NOT NULL,
+    saved_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+
+    FOREIGN KEY (uid)    REFERENCES users(uid)   ON DELETE CASCADE,
+    FOREIGN KEY (menuid) REFERENCES menu(menuid) ON DELETE CASCADE,
+    UNIQUE (uid, menuid)                          -- กด save ซ้ำไม่ได้
+);
+
+-- ============================================================
+--  Indexes
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_menu_uid        ON menu(uid);
+CREATE INDEX IF NOT EXISTS idx_menu_categoryid ON menu(categoryid);
+CREATE INDEX IF NOT EXISTS idx_menu_status     ON menu(status);
+CREATE INDEX IF NOT EXISTS idx_saved_uid       ON saved_menu(uid);
+
+-- ============================================================
+--  Sample Data
+-- ============================================================
+INSERT OR IGNORE INTO category (categoryname) VALUES
+    ('อาหารไทย'),
+    ('อาหารญี่ปุ่น'),
+    ('อาหารอิตาลี'),
+    ('ของหวาน'),
+    ('เครื่องดื่ม');
+
+INSERT OR IGNORE INTO users (name, username, email, password) VALUES
+    ('สมชาย ใจดี',  'chef_somchai', 'somchai@example.com', 'hashed_password_1'),
+    ('มาลี แสนสวย', 'malee_cook',   'malee@example.com',   'hashed_password_2');
+
+INSERT OR IGNORE INTO menu (uid, categoryid, mname, cooktime, description, status) VALUES
+    (1, 1, 'ผัดไทยสูตรดั้งเดิม', 25, 'ผัดไทยสูตรต้นตำรับ หอมกลิ่นกุ้งสด เส้นเหนียวนุ่ม', 'published'),
+    (2, 4, 'บัวลอยไข่หวาน',      50, 'บัวลอยแป้งสีสดใสในน้ำกะทิหวานมัน',                  'published');
+
+INSERT OR IGNORE INTO ingredient (menuid, ingredient_order, ingredient_name) VALUES
+    (1, 1, 'เส้นจันท์'),
+    (1, 2, 'กุ้งสด'),
+    (1, 3, 'ไข่ไก่'),
+    (1, 4, 'น้ำมะขามเปียก'),
+    (1, 5, 'น้ำตาลทราย'),
+    (1, 6, 'น้ำปลา');
+
+INSERT OR IGNORE INTO makestep (menuid, step_order, step) VALUES
+    (1, 1, 'แช่เส้นจันท์ในน้ำเย็นประมาณ 30 นาที จนเส้นนิ่ม แล้วพักให้สะเด็ดน้ำ'),
+    (1, 2, 'ตั้งกระทะบนไฟแรง ใส่น้ำมัน ผัดกุ้งจนสุก แล้วพักไว้'),
+    (1, 3, 'ใส่เส้นลงในกระทะ ตามด้วยน้ำมะขาม น้ำตาล และน้ำปลา ผัดให้เข้ากัน'),
+    (1, 4, 'เขี่ยเส้นออกด้านข้าง ตอกไข่ลงผัดให้สุก แล้วคลุกเข้ากับเส้น'),
+    (1, 5, 'ใส่กุ้งกลับลงไป ผัดรวมกัน ตักใส่จาน โรยถั่วลิสงและต้นหอม');
+
+INSERT OR IGNORE INTO saved_menu (uid, menuid) VALUES (2, 1);
+
+-- ============================================================
+--  Useful Queries
+-- ============================================================
+
+-- ดึงเมนูทั้งหมดพร้อม category และชื่อ user
+-- SELECT m.*, c.categoryname, u.username
+-- FROM menu m
+-- JOIN category c ON m.categoryid = c.categoryid
+-- JOIN users u    ON m.uid = u.uid
+-- WHERE m.status = 'published'
+-- ORDER BY m.created_at DESC;
+
+-- ดูเมนูตามหมวดหมู่
+-- SELECT m.* FROM menu m
+-- JOIN category c ON m.categoryid = c.categoryid
+-- WHERE c.categoryname = 'อาหารไทย' AND m.status = 'published';
+
+-- ดูสูตรที่ user บันทึกไว้
+-- SELECT m.*, s.saved_at
+-- FROM saved_menu s
+-- JOIN menu m ON s.menuid = m.menuid
+-- WHERE s.uid = 1
+-- ORDER BY s.saved_at DESC;
+
+-- นับจำนวน save ของแต่ละเมนู
+-- SELECT m.mname, COUNT(s.saveid) AS save_count
+-- FROM menu m
+-- LEFT JOIN saved_menu s ON m.menuid = s.menuid
+-- GROUP BY m.menuid
+-- ORDER BY save_count DESC;
+
+-- ดึง ingredient ทั้งหมดของเมนู
+-- SELECT * FROM ingredient
+-- WHERE menuid = 1
+-- ORDER BY ingredient_order;
+
+-- ดึง step ทั้งหมดของเมนู
+-- SELECT * FROM makestep
+-- WHERE menuid = 1
+-- ORDER BY step_order;


### PR DESCRIPTION
Expand menu API and evolve schema: GET / now returns published menus with category and author info plus batched ingredients and steps; GET /:menuid returns menu with ordered ingredients/steps; added POST / to create menu with batch insert of ingredients/steps and basic validation; added DELETE /:menuid to remove a menu (relying on ON DELETE CASCADE). Schema updates: enable PRAGMA foreign_keys, add username, created_at, cover_image, status, timestamps, and stronger constraints for menu/ingredient/makestep; introduce saved_menu table, useful indexes, sample data and example queries for common lookups.