### PR TITLE
Add category route

### DIFF
--- a/backend_easycook/src/routes/category.ts
+++ b/backend_easycook/src/routes/category.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+import { getDb } from "../db";
+
+const category = new Hono()
+
+category.get('/', async (c) =>{
+    try {
+        const db = getDb(c)
+        const r = await db.prepare('SELECT * FROM category').all()
+        return c.json(r.results || [])
+    }catch(err:any){
+        return c.json({ err:err?.message || String(err) },500)
+    }
+} )
+
+export default category

--- a/backend_easycook/src/routes/index.ts
+++ b/backend_easycook/src/routes/index.ts
@@ -1,10 +1,12 @@
 import { Hono } from 'hono'
 import users from './users'
 import menu from './menu'
+import category from './category'
 
 const routes = new Hono()
 
 routes.route('/users', users)
 routes.route('/menu', menu)
+routes.route('/category', category)
 
 export default routes


### PR DESCRIPTION
Add backend_easycook/src/routes/category.ts implementing a Hono route that returns all rows from the category table via getDb and handles errors. Update backend_easycook/src/routes/index.ts to import and mount the new /category route.