### PR TITLE
Adjust gap and card width in RecommendedMenu.vue

### DIFF
--- a/frontend-easycook/app/components/RecommendedMenu.vue
+++ b/frontend-easycook/app/components/RecommendedMenu.vue
@@ -8,11 +8,11 @@ const { data: menus } = await useAsyncData('menus', () =>
 
 <template>
     <div class="m-10">
-        <div class="flex gap-30">
+        <div class="flex gap-20">
             <div
                 v-for="m in menus"
                 :key="m.menuid"
-                class="bg-white rounded-2xl shadow hover:shadow-xl transition overflow-hidden cursor-pointer w-80"
+                class="bg-white rounded-2xl shadow hover:shadow-xl transition overflow-hidden cursor-pointer w-90"
             >
                 <!-- รูปภาพ -->
                 <div class="relative">


### PR DESCRIPTION
Tweaks layout in frontend-easycook/app/components/RecommendedMenu.vue: reduce container gap from gap-30 to gap-20 and increase card width class from w-80 to w-90 to refine spacing and card sizing.