### PR TITLE
Add auth middleware and protect pages

### DIFF
--- a/frontend-easycook/app/pages/app/recipe.vue
+++ b/frontend-easycook/app/pages/app/recipe.vue
@@ -1,6 +1,10 @@
 <script setup>
 import { TrashIcon, PhotoIcon } from "@heroicons/vue/24/outline"
 
+definePageMeta({
+    middleware: 'auth'
+})
+
 const config = useRuntimeConfig()
 const router = useRouter()
 

--- a/frontend-easycook/app/pages/index.vue
+++ b/frontend-easycook/app/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-navigateTo('/auth/register')
+navigateTo('/app/main')
 </script>
 
 <template>

--- a/frontend-easycook/middleware/auth.ts
+++ b/frontend-easycook/middleware/auth.ts
@@ -1,0 +1,8 @@
+export default defineNuxtRouteMiddleware(() => {
+    if (import.meta.client) {
+        const token = localStorage.getItem('token')
+        if (!token) {
+            return navigateTo('/auth/login')
+        }
+    }
+})

--- a/frontend-easycook/nuxt.config.ts
+++ b/frontend-easycook/nuxt.config.ts
@@ -9,7 +9,13 @@ export default defineNuxtConfig({
         }
     },
     compatibilityDate: '2025-07-15',
-    devtools: { enabled: true },
+    devtools: {
+      enabled: true,
+
+      timeline: {
+        enabled: true,
+      },
+    },
     css: ['./app/assets/css/main.css'],
     vite: {
         plugins:
@@ -27,5 +33,5 @@ export default defineNuxtConfig({
             apiBase: '',
             apiUrl: process.env.NUXT_PUBLIC_API_URL
         }
-    }
+    },
 })

--- a/frontend-easycook/tsconfig.json
+++ b/frontend-easycook/tsconfig.json
@@ -13,6 +13,6 @@
     },
     {
       "path": "./.nuxt/tsconfig.node.json"
-    }
+    },
   ]
 }


### PR DESCRIPTION
Introduce an auth route middleware that checks for a token in localStorage and redirects unauthenticated users to /auth/login. Apply this middleware to the recipe page via definePageMeta. Update root index redirect from /auth/register to /app/main. Enable DevTools timeline in nuxt.config and fix a minor formatting/structure issue in tsconfig.json.