### PR TITLE
Add password reset endpoint and UI

### DIFF
--- a/backend_easycook/src/routes/auth.ts
+++ b/backend_easycook/src/routes/auth.ts
@@ -6,6 +6,7 @@ import { Bindings } from "../types/bindings"
 
 export const auth = new Hono<{ Bindings: Bindings }>()
 
+//register
 auth.post("/register", async (c) => {
     const { name, username, email, password } = await c.req.json()
 
@@ -42,6 +43,7 @@ auth.post("/register", async (c) => {
     return c.json({ message: "สมัครสมาชิกสำเร็จ" }, 201)
 })
 
+//login
 auth.post("/login", async (c) => {
     const { identifier, password } = await c.req.json()
 
@@ -87,4 +89,38 @@ auth.post("/login", async (c) => {
             token : generateToken
         },
     })
+})
+
+
+//resetpass
+auth.post("/change-password", async (c) => {
+    const { username, email, newPassword } = await c.req.json()
+
+    if (!username || !email || !newPassword) {
+        return c.json({ message: "Missing fields" }, 400)
+    }
+
+    if (newPassword.length < 6) {
+        return c.json({ message: "Password must be at least 6 characters" }, 400)
+    }
+
+    const db = getDb(c)
+
+    const user = await db
+        .prepare("SELECT uid FROM users WHERE LOWER(email) = LOWER(?) AND LOWER(username) = LOWER(?)")
+        .bind(email, username)
+        .first()
+
+    if (!user) {
+        return c.json({ message: "ไม่พบผู้ใช้งาน" }, 404)
+    }
+
+    const hashed = await hashPassword(newPassword)
+
+    await db
+        .prepare("UPDATE users SET password = ? WHERE uid = ?")
+        .bind(hashed, user.uid)
+        .run()
+
+    return c.json({ message: "เปลี่ยนรหัสผ่านสำเร็จ" })
 })

--- a/frontend-easycook/app/pages/auth/login.vue
+++ b/frontend-easycook/app/pages/auth/login.vue
@@ -101,7 +101,9 @@ const handleLogin = async () => {
                     </div>
 
                     <div class="text-right">
-                        <a href="#" class="text-sm text-blue-500 hover:underline">ลืมรหัสผ่าน?</a>
+                        <NuxtLink to="/auth/resetpassword" class="text-sm text-blue-500 hover:underline">
+                            ลืมรหัสผ่าน?
+                        </NuxtLink>
                     </div>
 
                     <!-- ERROR -->

--- a/frontend-easycook/app/pages/auth/resetpassword.vue
+++ b/frontend-easycook/app/pages/auth/resetpassword.vue
@@ -2,27 +2,30 @@
 import { ref } from 'vue'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
 
+const config = useRuntimeConfig()
 const showPassword = ref(false)
 const showConfirmPassword = ref(false)
 
+const username = ref('')
 const email = ref('')
 const password = ref('')
 const confirmPassword = ref('')
 
 const errorMessage = ref('')
 const successMessage = ref('')
+const isLoading = ref(false)
 
-const handleResetPassword = () => {
+const handleResetPassword = async () => {
     errorMessage.value = ''
     successMessage.value = ''
 
-    if (!email.value || !password.value || !confirmPassword.value) {
+    if (!username.value || !email.value || !password.value || !confirmPassword.value) {
         errorMessage.value = 'กรุณากรอกข้อมูลให้ครบทุกช่อง'
         return
     }
 
     if (password.value.length < 6) {
-        errorMessage.value = 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร'
+        errorMessage.value = 'รหัสผ่านต้องมีอย่างน้อย 6 ตัวอักษร'
         return
     }
 
@@ -31,55 +34,81 @@ const handleResetPassword = () => {
         return
     }
 
-    successMessage.value = 'ตั้งรหัสผ่านใหม่สำเร็จ'
+    isLoading.value = true
+
+    try {
+        const res = await fetch(`${config.public.apiBase}/auth/change-password`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                username: username.value,
+                email: email.value,
+                newPassword: password.value,
+            }),
+        })
+
+        const data = await res.json()
+
+        if (!res.ok) {
+            errorMessage.value = data.message || 'เกิดข้อผิดพลาด'
+            return
+        }
+
+        successMessage.value = 'ตั้งรหัสผ่านใหม่สำเร็จ'
+        setTimeout(() => navigateTo('/auth/login'), 1500)
+
+    } catch {
+        errorMessage.value = 'ไม่สามารถเชื่อมต่อ server ได้'
+    } finally {
+        isLoading.value = false
+    }
 }
 </script>
 
 <template>
     <div class="min-h-screen flex">
 
-        <!-- LEFT IMAGE -->
         <div class="hidden md:block flex-[1.9] relative">
-            <img src="/easycook-mian.png" class="absolute inset-0 w-full h-full object-cover object-left" >
+            <img src="/Easycook mian.png" class="absolute inset-0 w-full h-full object-cover object-left">
         </div>
 
-        <!-- RIGHT FORM -->
         <div class="flex-1 flex items-center justify-center bg-white">
-
             <div class="w-full max-w-md p-10 bg-white rounded-3xl shadow-lg">
 
-                <!-- LOGO -->
                 <div class="flex justify-center mb-5">
-                    <img src="/logomain.png" class="h-10" >
+                    <img src="/logomain.png" class="h-10">
                 </div>
 
-                <h2 class="text-2xl font-bold text-center mb-6">
-                    ลืมรหัสผ่าน
-                </h2>
+                <h2 class="text-2xl font-bold text-center mb-6">ลืมรหัสผ่าน</h2>
 
                 <form class="space-y-5" @submit.prevent="handleResetPassword">
+
+                    <!-- Username -->
+                    <div>
+                        <label class="block text-sm text-gray-600">ชื่อผู้ใช้</label>
+                        <input
+                            v-model="username" type="text" placeholder="กรอกชื่อผู้ใช้ของคุณ"
+                            class="w-full mt-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-green-500">
+                    </div>
 
                     <!-- Email -->
                     <div>
                         <label class="block text-sm text-gray-600">อีเมลที่ใช้ล็อกอิน</label>
-                        <input 
+                        <input
                             v-model="email" type="email" placeholder="กรอกอีเมลของคุณ"
-                            class="w-full mt-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-green-500" >
+                            class="w-full mt-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-green-500">
                     </div>
 
                     <!-- Password -->
                     <div>
                         <label class="block text-sm text-gray-600">รหัสผ่านใหม่</label>
-
                         <div class="relative mt-1">
-                            <input 
+                            <input
                                 v-model="password" :type="showPassword ? 'text' : 'password'"
-                                class="w-full px-4 py-3 border border-gray-300 rounded-xl pr-12 focus:outline-none focus:ring-2 focus:ring-green-500" />
-
+                                class="w-full px-4 py-3 border border-gray-300 rounded-xl pr-12 focus:outline-none focus:ring-2 focus:ring-green-500">
                             <button 
                                 class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
-                                type="button" @click="showPassword = !showPassword"
-                                >
+                                type="button" @click="showPassword = !showPassword">
                                 <EyeIcon v-if="!showPassword" class="w-5 h-5" />
                                 <EyeSlashIcon v-else class="w-5 h-5" />
                             </button>
@@ -89,50 +118,35 @@ const handleResetPassword = () => {
                     <!-- Confirm -->
                     <div>
                         <label class="block text-sm text-gray-600">ยืนยันรหัสผ่านใหม่</label>
-
                         <div class="relative mt-1">
-                            <input 
+                            <input
                                 v-model="confirmPassword" :type="showConfirmPassword ? 'text' : 'password'"
-                                class="w-full px-4 py-3 border border-gray-300 rounded-xl pr-12 focus:outline-none focus:ring-2 focus:ring-green-500" />
-
+                                class="w-full px-4 py-3 border border-gray-300 rounded-xl pr-12 focus:outline-none focus:ring-2 focus:ring-green-500">
                             <button 
                                 class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
-                                type="button" @click="showConfirmPassword = !showConfirmPassword"
-                                >
+                                type="button" @click="showConfirmPassword = !showConfirmPassword">
                                 <EyeIcon v-if="!showConfirmPassword" class="w-5 h-5" />
                                 <EyeSlashIcon v-else class="w-5 h-5" />
                             </button>
                         </div>
                     </div>
 
-                    <!-- ERROR -->
-                    <p v-if="errorMessage" class="text-red-500 text-sm">
-                        {{ errorMessage }}
-                    </p>
+                    <p v-if="errorMessage" class="text-red-500 text-sm">{{ errorMessage }}</p>
+                    <p v-if="successMessage" class="text-green-600 text-sm">{{ successMessage }}</p>
 
-                    <!-- SUCCESS -->
-                    <p v-if="successMessage" class="text-green-600 text-sm">
-                        {{ successMessage }}
-                    </p>
-
-                    <!-- BUTTON -->
-                    <button 
-                        type="submit"
-                        class="w-full bg-green-600 text-white py-3 rounded-xl hover:bg-green-700 transition">
-                        ตั้งรหัสผ่านใหม่
+                    <button
+                        type="submit" :disabled="isLoading"
+                        class="w-full bg-green-600 text-white py-3 rounded-xl hover:bg-green-700 transition disabled:opacity-50 disabled:cursor-not-allowed">
+                        {{ isLoading ? 'กำลังดำเนินการ...' : 'ตั้งรหัสผ่านใหม่' }}
                     </button>
 
                     <p class="text-center text-sm">
                         กลับไป
-                        <NuxtLink to="/app/login" class="text-green-600 hover:underline">
-                            เข้าสู่ระบบ
-                        </NuxtLink>
+                        <NuxtLink to="/auth/login" class="text-green-600 hover:underline">เข้าสู่ระบบ</NuxtLink>
                     </p>
 
                 </form>
-
             </div>
-
         </div>
 
     </div>


### PR DESCRIPTION
Backend: add POST /auth/change-password in auth.ts to allow resetting a user's password by username+email (case-insensitive). Validates required fields and min length (6), looks up user, hashes new password and updates DB, and returns appropriate JSON messages. Also small organization comments around register/login handlers.

Frontend: wire the login page's "forgot password" link to /auth/resetpassword. Implement resetpassword.vue improvements: add username input, useRuntimeConfig for API base, async handler that POSTs to /auth/change-password, loading state and error/success handling, tighten password length message to 6 chars, disable button while loading, small markup/asset path and route fixes (redirect to /auth/login after success).